### PR TITLE
夢日記を作成するためのコンポーネントの追加

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import { Button } from 'react-native-elements';
 import AlarmCard from './components/AlarmCard';
 import AlarmSettingOverlay from './components/AlarmSettingOverlay';
 import RankingView from './RankingView';
+import DreamJournalModal from './components/DreamJournalModal';
 
 export default function App() {
   const [alarms, setAlarms] = useState([]);
@@ -35,6 +36,7 @@ export default function App() {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <RankingView />
+      <DreamJournalModal />
       <FlatList
         data={alarms}
         keyExtractor={(item, index) => index.toString()}

--- a/components/DreamJournalModal.js
+++ b/components/DreamJournalModal.js
@@ -11,7 +11,7 @@ import {
 import TagSelector from './TagSelector';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-export default function DreamJournalScreen() {
+export default function DreamJournalModal() {
   const [title, setTitle] = useState('');
   const [details, setDetails] = useState('');
   const [selectedTags, setSelectedTags] = useState([]);

--- a/components/DreamJournalModal.js
+++ b/components/DreamJournalModal.js
@@ -54,7 +54,6 @@ export default function DreamJournalModal() {
           setModalVisible(!modalVisible);
         }}
       >
-        {/* ここにモーダルの内容を追加 */}
         <Text style={styles.label}>夢のタイトル:</Text>
         <TextInput
           style={styles.input}
@@ -70,6 +69,42 @@ export default function DreamJournalModal() {
           placeholder="詳細を入力"
           multiline
         />
+        <Text style={styles.label}>場所:</Text>
+        <Picker
+          selectedValue={location}
+          onValueChange={(itemValue) => setLocation(itemValue)}
+        >
+          <Picker.Item label="#自宅" value="home" />
+          <Picker.Item label="#学校" value="school" />
+          <Picker.Item label="#仕事場" value="work" />
+          <Picker.Item label="#未知の場所" value="unknown" />
+        </Picker>
+
+        <Text style={styles.label}>登場人物:</Text>
+        <Picker
+          selectedValue={characters}
+          onValueChange={(itemValue) => setCharacters(itemValue)}
+        >
+          <Picker.Item label="#家族" value="family" />
+          <Picker.Item label="#友達" value="friends" />
+          <Picker.Item label="#有名人" value="celebrity" />
+          <Picker.Item label="#自分自身" value="self" />
+        </Picker>
+
+        <Text style={styles.label}>アクション:</Text>
+        <Picker
+          selectedValue={actions}
+          onValueChange={(itemValue) => setActions(itemValue)}
+        >
+          <Picker.Item label="#走る" value="run" />
+          <Picker.Item label="#飛ぶ" value="fly" />
+          <Picker.Item label="#話す" value="talk" />
+          <Picker.Item label="#戦う" value="fight" />
+        </Picker>
+        <Text style={styles.label}>日付:</Text>
+        <TouchableOpacity onPress={openDatePicker}>
+          <Text>{date.toDateString()}</Text>
+        </TouchableOpacity>
         <TagSelector
           selectedTags={selectedTags}
           setSelectedTags={setSelectedTags}

--- a/components/DreamJournalModal.js
+++ b/components/DreamJournalModal.js
@@ -83,22 +83,34 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 16,
+    margin: 16,
   },
   label: {
-    fontSize: 16,
+    fontSize: 18,
+    fontWeight: 'bold',
     marginBottom: 8,
+    margin: 16,
   },
   input: {
     borderWidth: 1,
     borderColor: '#ccc',
-    padding: 8,
+    padding: 10,
+    borderRadius: 5,
+    marginTop: 0,
+    marginRight: 16,
     marginBottom: 16,
+    marginLeft: 16,
   },
+  
   textArea: {
     borderWidth: 1,
     borderColor: '#ccc',
-    padding: 8,
+    padding: 10,
+    borderRadius: 5,
     height: 100,
+    marginTop: 0,
+    marginRight: 16,
     marginBottom: 16,
+    marginLeft: 16,
   },
 });

--- a/components/DreamJournalModal.js
+++ b/components/DreamJournalModal.js
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  Button,
+  TouchableOpacity,
+} from 'react-native';
+import TagSelector from './TagSelector';
+
+export default function DreamJournalScreen() {
+  const [title, setTitle] = useState('');
+  const [details, setDetails] = useState('');
+  const [selectedTags, setSelectedTags] = useState([]);
+  const [modalVisible, setModalVisible] = useState(false);
+
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity onPress={() => setModalVisible(true)}>
+        <Text>夢日記を記録する</Text>
+      </TouchableOpacity>
+
+      <Modal
+        animationType="slide"
+        transparent={false}
+        visible={modalVisible}
+        onRequestClose={() => {
+          setModalVisible(!modalVisible);
+        }}
+      >
+        {/* ここにモーダルの内容を追加 */}
+        <Text style={styles.label}>夢のタイトル:</Text>
+        <TextInput
+          style={styles.input}
+          value={title}
+          onChangeText={setTitle}
+          placeholder="タイトルを入力"
+        />
+        <Text style={styles.label}>夢の詳細:</Text>
+        <TextInput
+          style={styles.textArea}
+          value={details}
+          onChangeText={setDetails}
+          placeholder="詳細を入力"
+          multiline
+        />
+        <TagSelector
+          selectedTags={selectedTags}
+          setSelectedTags={setSelectedTags}
+        />
+        <Button title="記録する" onPress={handleSave} />
+        <Button title="閉じる" onPress={() => setModalVisible(false)} />
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  label: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 16,
+  },
+  textArea: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    height: 100,
+    marginBottom: 16,
+  },
+});

--- a/components/DreamJournalModal.js
+++ b/components/DreamJournalModal.js
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import TagSelector from './TagSelector';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default function DreamJournalScreen() {
   const [title, setTitle] = useState('');
@@ -16,6 +17,26 @@ export default function DreamJournalScreen() {
   const [selectedTags, setSelectedTags] = useState([]);
   const [modalVisible, setModalVisible] = useState(false);
 
+  const handleSave = async () => {
+    try {
+      const dreamJournalData = { title, details, selectedTags };
+      const storedData = await AsyncStorage.getItem('dreamJournal');
+      let storedDataArray = [];
+
+      if (storedData) {
+        storedDataArray = JSON.parse(storedData);
+      }
+
+      storedDataArray.push(dreamJournalData);
+      await AsyncStorage.setItem(
+        'dreamJournal',
+        JSON.stringify(storedDataArray)
+      );
+      console.log('Saved:', dreamJournalData);
+    } catch (error) {
+      console.error('Could not save data', error);
+    }
+  };
 
   return (
     <View style={styles.container}>

--- a/components/DreamJournalModal.js
+++ b/components/DreamJournalModal.js
@@ -33,6 +33,8 @@ export default function DreamJournalModal() {
         JSON.stringify(storedDataArray)
       );
       console.log('Saved:', dreamJournalData);
+
+      setModalVisible(false);
     } catch (error) {
       console.error('Could not save data', error);
     }

--- a/components/TagSelector.js
+++ b/components/TagSelector.js
@@ -37,7 +37,7 @@ export default function TagSelector({ selectedTags, setSelectedTags }) {
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: 16,
+    margin: 16,
   },
   label: {
     fontSize: 16,

--- a/components/TagSelector.js
+++ b/components/TagSelector.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+const tags = [
+  { label: '#喜び', value: 'joy' },
+  { label: '#怒り', value: 'anger' },
+  { label: '#驚き', value: 'surprise' },
+  // 他のタグもここに追加
+];
+
+export default function TagSelector({ selectedTags, setSelectedTags }) {
+  const toggleTag = (tagValue) => {
+    if (selectedTags.includes(tagValue)) {
+      setSelectedTags(selectedTags.filter((t) => t !== tagValue));
+    } else {
+      setSelectedTags([...selectedTags, tagValue]);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>タグ:</Text>
+      <View style={styles.tagContainer}>
+        {tags.map((tag, index) => (
+          <TouchableOpacity
+            key={index}
+            style={[styles.tag, selectedTags.includes(tag.value) && styles.selectedTag]}
+            onPress={() => toggleTag(tag.value)}
+          >
+            <Text style={styles.tagLabel}>{tag.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  tagContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  tag: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    borderRadius: 16,
+    margin: 4,
+  },
+  selectedTag: {
+    backgroundColor: '#ccc',
+  },
+  tagLabel: {
+    fontSize: 14,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front-end",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.19.3",
         "@react-native-community/datetimepicker": "7.2.0",
         "@react-navigation/native": "^6.1.8",
         "@react-navigation/stack": "^6.3.18",
@@ -18,8 +19,7 @@
         "expo-status-bar": "~1.6.0",
         "react": "18.2.0",
         "react-native": "0.72.5",
-        "react-native-elements": "^3.4.3",
-        "typescript": "^5.1.3"
+        "react-native-elements": "^3.4.3"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -3795,6 +3795,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.19.3.tgz",
+      "integrity": "sha512-CwGfoHCWdPOTPS+2fW6YRE1fFBpT9++ahLEroX5hkgwyoQ+TkmjOaUxixdEIoVua9Pz5EF2pGOIJzqOTMWfBlA==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || 0.60 - 0.72 || 1000.0.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -8944,6 +8955,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -10380,6 +10399,17 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -13684,18 +13714,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,18 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.19.3",
+    "@react-native-community/datetimepicker": "7.2.0",
     "@react-navigation/native": "^6.1.8",
     "@react-navigation/stack": "^6.3.18",
     "@rneui/base": "^4.0.0-rc.7",
     "@rneui/themed": "^4.0.0-rc.8",
     "expo": "~49.0.13",
+    "expo-notifications": "~0.20.1",
     "expo-status-bar": "~1.6.0",
     "react": "18.2.0",
     "react-native": "0.72.5",
-    "react-native-elements": "^3.4.3",
-    "expo-notifications": "~0.20.1",
-    "@react-native-community/datetimepicker": "7.2.0"
+    "react-native-elements": "^3.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
### 概要
夢日記の作成に関するコンポーネントを作成しました

### 現状の画面
![image](https://github.com/Geek-Camp-Hackathon/front-end/assets/119847001/b973d059-7fac-4050-8c31-e03825798bf4)

### 今後の対応

- UIの改善
- 項目の追加
  場所: 夢の舞台となった場所。例: #自宅, #学校, #仕事場, #未知の場所
  登場人物: 夢に登場した人物やキャラクター。例: #家族, #友達, #有名人, #自分自身
  アクション: 夢で行った主要な行動。例: #走る, #飛ぶ, #話す, #戦う
  テーマ性: 夢全体のテーマ性やジャンル。例: #冒険, #恋愛, #ホラー, #日常
  日付

- 入力したデータを表示するコンポーネントの作成
- 画像生成で見た夢を再現する機能の追加
- ChatGPT APIを利用して見た夢を分析する機能の追加